### PR TITLE
Fix doublelabel

### DIFF
--- a/samples/testLabel.s
+++ b/samples/testLabel.s
@@ -1,0 +1,11 @@
+.text
+
+main:
+
+
+
+
+
+
+	movabsq $1, %rax
+	ret

--- a/samples/testgetchar.s
+++ b/samples/testgetchar.s
@@ -1,0 +1,4 @@
+
+main:
+	call getchar
+	jmp main

--- a/src/app/ConsoleView.jsx
+++ b/src/app/ConsoleView.jsx
@@ -88,17 +88,14 @@ export default class Console extends React.Component {
    */
   read(n=1) {
     let read = this.inbuf.slice(0,n);
-
     if (this.inbuf.length >= n) {
       this.inbuf = this.inbuf.slice(n);
     } else {
-      this.infbuf = '';
-
+      this.inbuf = '';
       // Prompt for user input
       this.setState({interactive: false});
       this.focusInput();
     }
-
     return read;
   }
 

--- a/src/app/StackView.jsx
+++ b/src/app/StackView.jsx
@@ -216,11 +216,13 @@ class StackItem extends React.Component {
 	}
 
 	componentDidMount() {
-		this.refs.item.scrollIntoView({
-			block: this.props.growsUp ? 'end' : 'start', 
-			inline: 'nearest', 
-			behavior: 'smooth'
-		});
+		if (this.props.pointer === '%rsp') {
+			this.refs.item.scrollIntoView({
+				block: this.props.growsUp ? 'end' : 'start', 
+				inline: 'nearest', 
+				behavior: 'smooth'
+			});
+		}
 	}
 
 	render() {

--- a/src/app/TextView.jsx
+++ b/src/app/TextView.jsx
@@ -105,7 +105,7 @@ class InstructionView extends React.Component {
 
         return (
             <div ref="thisinst" style={highlightStyle} className="instruction">
-                <span className="instruction-label">{this.props.label && this.props.label + ':'}</span>
+                <span className="instruction-label">{this.props.label && this.props.label.join(': ') + ':'}</span>
                 <span className="instruction-address"
                     onClick={this.toggleBreakpoint}
                     style={addrStyle}>

--- a/src/vm/Assembler.js
+++ b/src/vm/Assembler.js
@@ -89,7 +89,9 @@ class Assembly {
 			// Parse label and identify with linenum (and remove from instruction)
 			if (tokens[0] && tokens[0].endsWith(':')) {
 				// TODO: ignore compiler-generated labels
-				this.labelFor[this.linenum] = tokens.shift().slice(0,-1);
+				// Use a list of labels for each line number, in case there are multiple
+				this.labelFor[this.linenum] = this.labelFor[this.linenum] || [];
+				this.labelFor[this.linenum].push(tokens.shift().slice(0,-1));
 			}
 
 			// Remove empty tokens
@@ -201,7 +203,9 @@ class Assembly {
 		for (const linenum in this.instructions) {
 			// Convert line number to label
 			if (linenum in this.labelFor) {
-				this.labels[this.labelFor[linenum]] = addr;
+				for (let label of this.labelFor[linenum]) {
+					this.labels[label] = addr;
+				}
 			}
 
 			image.text.addresses.push(addr);
@@ -234,8 +238,11 @@ class Assembly {
 
 		for (const linenum in data) {
 			// Convert line number to label
-			if (this.labelFor[linenum] !== undefined)
-				this.labels[this.labelFor[linenum]] = addr;
+			if (this.labelFor[linenum] !== undefined) {
+				for (let label of this.labelFor[linenum]) {
+					this.labels[label] = addr;
+				}
+			}
 
 			let item = data[linenum];
 			//console.log(`allocating ${item.type}: ${item.value}`);

--- a/src/vm/Process.js
+++ b/src/vm/Process.js
@@ -34,8 +34,10 @@ class Process {
         // Save the labels and reverse the label mapping
         this.labels = labels;
         this.labeled = {};
-        for (let label in this.labels)
-            this.labeled[this.labels[label]] = label;
+        for (let label in this.labels) {
+            this.labeled[this.labels[label]] = this.labeled[this.labels[label]] || [];
+            this.labeled[this.labels[label]].push(label);
+        }
 
         // Object containing handlers indexed by instruction
         this.chip = arch.chip.call(this);

--- a/src/vm/lib.js
+++ b/src/vm/lib.js
@@ -164,7 +164,6 @@ export function Stdlib(io) {
 				this.signals.register('SIGIO', _getchar);
 
 				let ch = io.stdin.read();
-				console.log(`read: ${ch}`);
 				if (ch === '') return;
 
 				this.blocked = false;
@@ -265,51 +264,10 @@ export function Stdlib(io) {
 			_scanf();
 		},
 
-		/**
-		 *
-		 */
-		scanf_real: () => {
-			throw new Error('not implemented');
-
-			let fmtString = readString(SysV_arg(0));
-
-			// Parse the format string and determine what to read
-			let sections = fmtString.split(/(%(?:[dics]))/g);
-
-			// State of the parser, which segment are we reading
-			let iSection = 0;
-			let iChar = 0;
-			let nRead = 0;
-
-			// Define the actual handler asynchonously
-			const _scanf = () => {
-				let ch;
-				let s = sections[iSection];
-
-				// Block process and setup event handler for input
-				this.blocked = true;
-				this.signals.register('SIGIO', _scanf);
-
-				// Keep reading stuff
-				while ((ch = io.stdin.read()) !== EOF) {
-					// Nothing in the buffer, wait for next interrupt
-					if (ch === null)
-						return;
-
-					// Handle beginning of next section
-					if (iChar == null) {
-
-					}
-				}
-
-				// Allow process to resume and unregister input handler
-				this.blocked = false;
-				this.signals.unregister('SIGIO');
-				SysV_ret(nRead);
-			};
-
-			// Call the asynchronous _scanf
-			_scanf();
+		isspace() {
+			let ch = +SysV_arg(0);
+			let is = [9, 10, 11, 12, 13, 32, 133, 160].indexOf(ch) > 0;
+			SysV_ret(is ? 1 : 0);
 		},
 
 		exit: (override) => {


### PR DESCRIPTION
Fixes a bug where two consecutive labels were replaced with only the second one.  Also fixed a bug in the Console which prevented it from ever exhausting its buffer, added the `isspace` function to the library, and removed the weird scroll behavior when a new stack break was added.

See commits for more details.